### PR TITLE
Add module name search to locator

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ dependencies {
 }
 ```
 
-The latest versions can be checked by looking at the [releases](https://github.com/alcatrazEscapee/mcjunitlib/releases) page. As of time of writing (2021-08-04), the latest versions are:
+The latest versions can be checked by looking at the [releases](https://github.com/alcatrazEscapee/mcjunitlib/releases) page. As of time of writing (2021-09-04), the latest versions are:
 
 - Minecraft 1.16.5: `1.4.3` (Latest)
 - Minecraft 1.15.2: `1.0.1`

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ dependencies {
 }
 ```
 
-The latest versions can be checked by looking at the [releases](https://github.com/alcatrazEscapee/mcjunitlib/releases) page. As of time of writing (2021-04-17), the latest versions are:
+The latest versions can be checked by looking at the [releases](https://github.com/alcatrazEscapee/mcjunitlib/releases) page. As of time of writing (2021-08-04), the latest versions are:
 
 - Minecraft 1.16.5: `1.4.3` (Latest)
 - Minecraft 1.15.2: `1.0.1`
@@ -32,7 +32,7 @@ The latest versions can be checked by looking at the [releases](https://github.c
 Note: This mod will package the JUnit 5 API as part of the mod jar. This is important - do not add a dependency on JUnit manually as Forge will only load mod classes using the transforming class loader which is required in order to access minecraft source code without everything crashing and burning.
 
 ## Adding the run configuration
-Add a new run configuration to the `build.gradle` file with the following, placed inside the `minecraft { runs }` block. After adding this section, you will need to continue reading to add an environment variable for the system to locate your unit tests.
+Add a new run configuration to the `build.gradle` file with the following, placed inside the `minecraft { runs }` block. After adding this section, continue reading to add an environment variable for the system to locate your unit tests.
 
 - Make sure to replace `modid` with your mod id, or use the `${mod_id}` replacement.
 - The `arg '--crashOnFailedTests'` is optional, recommended for a CI environment, it will cause failed tests to crash the server and exit (as opposed to continuing to run the server, allowing a local player to connect and inspect failed tests).

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The latest versions can be checked by looking at the [releases](https://github.c
 Note: This mod will package the JUnit 5 API as part of the mod jar. This is important - do not add a dependency on JUnit manually as Forge will only load mod classes using the transforming class loader which is required in order to access minecraft source code without everything crashing and burning.
 
 ## Adding the run configuration
-Add a new run configuration to the `build.gradle` file with the following, placed inside the `minecraft { runs }` block.
+Add a new run configuration to the `build.gradle` file with the following, placed inside the `minecraft { runs }` block. After adding this section, you will need to continue reading to add an environment variable for the system to locate your unit tests.
 
 - Make sure to replace `modid` with your mod id, or use the `${mod_id}` replacement.
 - The `arg '--crashOnFailedTests'` is optional, recommended for a CI environment, it will cause failed tests to crash the server and exit (as opposed to continuing to run the server, allowing a local player to connect and inspect failed tests).
@@ -74,7 +74,7 @@ environment 'MOD_CLASSES', testClasspaths   // target specific classpaths
 ### Use named module classpaths
 This option is similar to how Intellij and Eclipse load unit tests natively. 
 ```groovy
-def testModules = String.join(File.pathSeparator, "${mod_id}%%${mod_id}%%${project.name}.test")
+def testModules = String.join(File.pathSeparator, "${mod_id}%%${project.name}.test")
 ```
 
 And then, inside the `serverTest` block, add the following line:

--- a/README.md
+++ b/README.md
@@ -31,14 +31,12 @@ The latest versions can be checked by looking at the [releases](https://github.c
 
 Note: This mod will package the JUnit 5 API as part of the mod jar. This is important - do not add a dependency on JUnit manually as Forge will only load mod classes using the transforming class loader which is required in order to access minecraft source code without everything crashing and burning.
 
-Then, in order to setup tests, the following run configuration is required:
+## Adding the run configuration
+Add a new run configuration to the `build.gradle` file with the following, placed inside the `minecraft { runs }` block.
 
 - Make sure to replace `modid` with your mod id, or use the `${mod_id}` replacement.
 - The `arg '--crashOnFailedTests'` is optional, recommended for a CI environment, it will cause failed tests to crash the server and exit (as opposed to continuing to run the server, allowing a local player to connect and inspect failed tests).
 - The `forceExit = false` is optional, recommended for a CI environment, when not using the IDE run configurations.
-
-## Adding the run configuration
-Add a new run configuration to the `build.gradle` file with the following, placed inside the `minecraft { runs }` block:
 
 ```groovy
 serverTest {

--- a/src/main/java/com/alcatrazescapee/mcjunitlib/JUnitTestRunner.java
+++ b/src/main/java/com/alcatrazescapee/mcjunitlib/JUnitTestRunner.java
@@ -51,11 +51,26 @@ public class JUnitTestRunner implements TestExecutionListener
                 return Paths.get(splitString[splitString.length - 1]);
             })
             .collect(Collectors.toSet());
-        LOGGER.debug("Found supplied mod coordinates [{}]", modClassPaths);
+
+        String moduleNamesString = Optional.ofNullable(System.getenv("MOD_MODULES")).orElse("");
+        LOGGER.debug("Got module names {} from env", moduleNamesString);
+        Set<String> moduleNames = Arrays.stream(moduleNamesString.split(File.pathSeparator))
+                        .map(mod -> {
+                            String[] splitString = mod.split("%%", 2);
+                            return splitString[splitString.length - 1];
+                        }).collect(Collectors.toSet());
+
+        if(!modClassPaths.isEmpty())
+            LOGGER.debug("Found supplied mod coordinates [{}]", modClassPaths);
+
+        if(!moduleNames.isEmpty())
+            LOGGER.debug("Found supplied module names [{}]", moduleNames);
 
         LauncherDiscoveryRequest request = LauncherDiscoveryRequestBuilder.request()
             .selectors(DiscoverySelectors.selectClasspathRoots(modClassPaths))
+            .selectors(DiscoverySelectors.selectModules(moduleNames))
             .build();
+
         Launcher launcher = LauncherFactory.create();
         TestPlan testPlan = launcher.discover(request);
 


### PR DESCRIPTION
This PR cleans up logging ever so slightly (by gating a debug entry behind if the classpath locator found anything) as well as adding support for JUnit's module name discoverer.

JUnit can also locate tests under module classpaths, which IMO is far easier to use. Specify the modules the same way classpaths are specified with `MOD_CLASSES`, only use `MOD_MODULES` instead.

Add the following to `build.gradle` to use:
```groovy
environment 'MOD_MODULES', String.join(File.pathSeparator, "${mod_id}%%${project.name}.test")
```


I've tested this against Compact Crafting, and it helps me to close #5 with ease. Found my tests no problem, when the classpath locator didn't (and trust me - I dug around in the classpath code ***a lot***.)